### PR TITLE
fix: push WAL-index changes during shm_barrier when holding exclusive WAL lock

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1712,28 +1712,26 @@ mod io {
             return;
         };
 
-        if state.has_exclusive_lock && !readonly {
+        let has_exclusive_wal = state
+            .wal_index_locks
+            .iter()
+            .any(|(_, lock)| *lock == wip::WalIndexLock::Exclusive);
+
+        if (state.has_exclusive_lock || has_exclusive_wal) && !readonly {
             log::trace!(
-                "[{}] has exclusive db lock, pushing wal index changes",
+                "[{}] has exclusive lock (db={} wal={}), pushing wal index changes",
                 state.id,
+                state.has_exclusive_lock,
+                has_exclusive_wal,
             );
             for (region, data) in &mut state.wal_index_regions {
                 if let Err(err) = wal_index.push(*region as u32, data) {
                     log::error!("[{}] pushing wal index changes failed: {}", state.id, err)
                 }
             }
-
-            return;
-        }
-
-        let has_exclusive = state
-            .wal_index_locks
-            .iter()
-            .any(|(_, lock)| *lock == wip::WalIndexLock::Exclusive);
-
-        if !has_exclusive {
+        } else {
             log::trace!(
-                "[{}] does not have wal index write lock, pulling changes",
+                "[{}] does not have exclusive lock, pulling changes",
                 state.id
             );
             for (region, data) in &mut state.wal_index_regions {


### PR DESCRIPTION
## Problem

`shm_barrier` had a logic bug that caused ~40% `SQLITE_CORRUPT` failures under concurrent WAL access (1 writer + multiple readers).

The barrier function had three branches:
1. `has_exclusive_lock` (exclusive DB lock) → PUSH
2. `has_exclusive_wal_index` (exclusive WAL-index lock) → **no-op**
3. else → PULL

Branch 2 is wrong. The normal SQLite WAL write path acquires an exclusive WAL-index lock **without** an exclusive DB lock (the writer holds RESERVED on the DB, EXCLUSIVE on WAL-index slot 0). In this state, the writer's WAL-index updates were never pushed to shared memory during `shm_barrier`, so readers saw stale WAL-index data → `SQLITE_CORRUPT`.

## Fix

Change the condition to push when holding **either** an exclusive DB lock **or** an exclusive WAL-index lock:

```rust
// Before: only pushed for exclusive DB lock, not exclusive WAL lock
if state.has_exclusive_lock && !readonly {
    // PUSH
} else if has_exclusive_wal_index {
    // no-op  ← BUG: writer doesn't push during barrier
} else {
    // PULL
}

// After: push for exclusive DB lock OR exclusive WAL lock
let has_exclusive_wal = state.wal_index_locks.iter()
    .any(|(_, lock)| *lock == wip::WalIndexLock::Exclusive);
if (state.has_exclusive_lock || has_exclusive_wal) && !readonly {
    // PUSH
} else {
    // PULL
}
```

## Testing

Stress-tested with 1 writer + 4 concurrent readers for 5 seconds:
- Before fix: ~40% failure rate (SQLITE_CORRUPT)
- After fix: 0% failure rate across 30 runs

Discovered while building [turbolite](https://github.com/russellromney/turbolite), a SQLite VFS for S3-backed storage.